### PR TITLE
Made sanitizeToken more strict and use correct alphabet

### DIFF
--- a/acme-http01-webroot.lua
+++ b/acme-http01-webroot.lua
@@ -84,8 +84,8 @@ end
 -- see https://github.com/letsencrypt/acme-spec/blob/master/draft-barnes-acme.md
 --
 function sanitizeToken(token)
-	_strip="[^%a%d%+%-%_=]"
-	token = token:gsub(_strip,'')
+	local pattern="^[%a%d%-_]+$"
+	token = token:match(pattern)
 	return token
 end
 


### PR DESCRIPTION
- \+ and = are illegal in challenge tokens (url safe variant of base64 without padding)
- instead of replacing illegal characters (gsub) only accept the token if it only contains valid characters at every position and is at least one character long
- newline at end of file (posix standard)
