### PR TITLE
Cert subject parsing supporting Ubuntu 18.04 / OpenSSL 1.1.0g

### DIFF
--- a/cert-renewal-haproxy.sh
+++ b/cert-renewal-haproxy.sh
@@ -66,7 +66,7 @@ renewed_certs=()
 exitcode=0
 while IFS= read -r -d '' cert; do
   if ! openssl x509 -noout -checkend $((4*7*86400)) -in "${cert}"; then
-    subject="$(openssl x509 -noout -subject -in "${cert}" | rev | cut -d'=' -f1 | rev | awk '{$1=$1};1')"
+    subject="$(openssl x509 -noout -subject -in "${cert}" | sed -r 's/.*CN ?= ?(.*)/\1/')"
     subjectaltnames="$(openssl x509 -noout -text -in "${cert}" | sed -n '/X509v3 Subject Alternative Name/{n;p}' | sed 's/\s//g' | tr -d 'DNS:' | sed 's/,/ /g')"
     domains="-d ${subject}"
     for name in ${subjectaltnames}; do

--- a/cert-renewal-haproxy.sh
+++ b/cert-renewal-haproxy.sh
@@ -66,7 +66,7 @@ renewed_certs=()
 exitcode=0
 while IFS= read -r -d '' cert; do
   if ! openssl x509 -noout -checkend $((4*7*86400)) -in "${cert}"; then
-    subject="$(openssl x509 -noout -subject -in "${cert}" | grep -o -E 'CN=[^ ,]+' | tr -d 'CN=')"
+    subject="$(openssl x509 -noout -subject -in "${cert}" | rev | cut -d'=' -f1 | rev | awk '{$1=$1};1')"
     subjectaltnames="$(openssl x509 -noout -text -in "${cert}" | sed -n '/X509v3 Subject Alternative Name/{n;p}' | sed 's/\s//g' | tr -d 'DNS:' | sed 's/,/ /g')"
     domains="-d ${subject}"
     for name in ${subjectaltnames}; do


### PR DESCRIPTION
Using this script on Ubuntu 18.04 with OpenSSL 1.1.0g the subject is not parsed correctly resulting in wrong certboot command with and `-d` with an empty argument and fails the execution.

This PR fixes this on Ubuntu 18.04 with OpenSSL 1.1.0g, hope it does not break other versions.